### PR TITLE
Fix stale data appearing when closing task modal

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -1023,11 +1023,12 @@ Module.register("MMM-Todoist", {
 				Log.log("MMM-Todoist: Modal closed, applying pending update");
 			}
 			this.applyTasksData(this.pendingTasksData);
-
-			// Clear pending data
-			this.pendingTasksData = null;
-			this.hasPendingUpdate = false;
 		}
+
+		// Always clear pending data, even if not applied
+		// This prevents stale data from persisting across modal sessions
+		this.pendingTasksData = null;
+		this.hasPendingUpdate = false;
 	},
 
 	/**


### PR DESCRIPTION
The pending task data (pendingTasksData, hasPendingUpdate) was only cleared inside the conditional block that applies it. When skipPendingUpdate=true (e.g., after task completion), the data was not applied but also not cleared, causing it to persist indefinitely. This stale data would then be applied the next time a modal was closed normally, replacing fresh data with potentially hours-old data.

Fix: Always clear pending data after modal closes, regardless of whether it was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)