### PR TITLE
Migrate to Todoist API v1 and fix silent error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ package-lock.json
 
 # Test output
 test/output/
+
+# Scratch/notes folder
+scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ Module configuration is passed through MagicMirror's `config/config.js`. Key con
 
 ## Todoist API
 
-Uses Todoist Sync API v9:
-- Endpoint: `https://todoist.com/API/v9/sync/`
+Uses Todoist Sync API v1:
+- Endpoint: `https://api.todoist.com/api/v1/sync/`
 - Authentication: Bearer token in Authorization header
 - Resource types: items, projects, collaborators, user, labels, sections
 - Returns comprehensive task data including project colors, collaborators, labels, and sections

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -91,8 +91,8 @@ Module.register("MMM-Todoist", {
 		enableTaskCompletion: true, // enable tap-to-complete functionality
 
 		// Non-configurable parameters
-		apiVersion: "v9",
-		apiBase: "https://todoist.com/API",
+		apiVersion: "v1",
+		apiBase: "https://api.todoist.com/api",
 		todoistEndpoint: "sync",
 		todoistResourceType: "[\"items\", \"projects\", \"collaborators\", \"user\", \"labels\", \"sections\"]",
 
@@ -125,6 +125,7 @@ Module.register("MMM-Todoist", {
 		//to display "Loading..." at start-up
 		this.title = "Loading...";
 		this.loaded = false;
+		this.errorMessage = null;
 
 		// Modal state tracking for deferred DOM updates
 		this.isModalOpen = false;
@@ -277,6 +278,10 @@ Module.register("MMM-Todoist", {
 			this.sendSocketNotification("FETCH_TODOIST", this.config);
 		} else if (notification === "FETCH_ERROR") {
 			Log.error("Todoist Error. Could not fetch todos: " + payload.error);
+			if (!this.loaded) {
+				this.errorMessage = "Todoist Error: " + payload.error;
+				this.updateDom();
+			}
 		} else if (notification === "TASK_COMPLETED") {
 			// Task was successfully completed
 			// Clear the completion timeout since we received a response
@@ -1244,7 +1249,7 @@ Module.register("MMM-Todoist", {
 
 		//display "loading..." if not loaded
 		if (!this.loaded) {
-			wrapper.innerHTML = "Loading...";
+			wrapper.innerHTML = this.errorMessage || "Loading...";
 			wrapper.className = "dimmed light small";
 			return wrapper;
 		}

--- a/node_helper.js
+++ b/node_helper.js
@@ -63,21 +63,31 @@ module.exports = NodeHelper.create({
 				console.log(body);
 			}
 			if (response.statusCode === 200) {
-				var taskJson = JSON.parse(body);
-				taskJson.items.forEach((item)=>{
-					item.contentHtml = markdown.makeHtml(item.content);
-				});
+				try {
+					var taskJson = JSON.parse(body);
+					taskJson.items.forEach((item)=>{
+						item.contentHtml = markdown.makeHtml(item.content);
+					});
 
-				taskJson.accessToken = accessCode;
+					taskJson.accessToken = accessCode;
 
-				if (callback) {
-					callback(self, taskJson);
-				} else {
-					self.sendSocketNotification("TASKS", taskJson);
+					if (callback) {
+						callback(self, taskJson);
+					} else {
+						self.sendSocketNotification("TASKS", taskJson);
+					}
+				} catch (e) {
+					console.error("MMM-Todoist: Error parsing API response: " + e.message);
+					self.sendSocketNotification("FETCH_ERROR", {
+						error: "Failed to parse Todoist response: " + e.message
+					});
 				}
 			}
 			else{
 				console.log("Todoist api request status="+response.statusCode);
+				self.sendSocketNotification("FETCH_ERROR", {
+					error: "Todoist API returned HTTP " + response.statusCode
+				});
 			}
 
 		});
@@ -154,10 +164,22 @@ module.exports = NodeHelper.create({
 				console.log(body);
 			}
 			if (response.statusCode === 200) {
-				var taskJson = JSON.parse(body);
-				itemid = taskJson["temp_id_mapping"][JSON.stringify(tmpid)];
-				// Send ADDITEM only after API confirms subtask was created
-				self.sendSocketNotification("ADDITEM", itemid);
+				try {
+					var taskJson = JSON.parse(body);
+					itemid = taskJson["temp_id_mapping"][JSON.stringify(tmpid)];
+					// Send ADDITEM only after API confirms subtask was created
+					self.sendSocketNotification("ADDITEM", itemid);
+				} catch (e) {
+					console.error("MMM-Todoist: Error parsing sub-item response: " + e.message);
+					self.sendSocketNotification("ADDNEWSUBITEM_ERROR", {
+						error: "Failed to parse response: " + e.message
+					});
+				}
+			} else {
+				console.error("MMM-Todoist: Add sub-item failed with status " + response.statusCode);
+				self.sendSocketNotification("ADDNEWSUBITEM_ERROR", {
+					error: "Todoist API returned HTTP " + response.statusCode
+				});
 			}
 		});
 	},
@@ -215,14 +237,26 @@ module.exports = NodeHelper.create({
 				console.log(body);
 			}
 			if (response.statusCode === 200) {
-				var taskJson = JSON.parse(body);
-				itemid = taskJson["temp_id_mapping"][tmpid];
-				if (callback) {
-					callback(self, proj, self.addData.message, itemid, section);
-				} else {
-					// Send ADDITEM only after API confirms task was created
-					self.sendSocketNotification("ADDITEM", itemid);
+				try {
+					var taskJson = JSON.parse(body);
+					itemid = taskJson["temp_id_mapping"][tmpid];
+					if (callback) {
+						callback(self, proj, self.addData.message, itemid, section);
+					} else {
+						// Send ADDITEM only after API confirms task was created
+						self.sendSocketNotification("ADDITEM", itemid);
+					}
+				} catch (e) {
+					console.error("MMM-Todoist: Error parsing add-item response: " + e.message);
+					self.sendSocketNotification("ADDNEWITEM_ERROR", {
+						error: "Failed to parse response: " + e.message
+					});
 				}
+			} else {
+				console.error("MMM-Todoist: Add item failed with status " + response.statusCode);
+				self.sendSocketNotification("ADDNEWITEM_ERROR", {
+					error: "Todoist API returned HTTP " + response.statusCode
+				});
 			}
 		});
 	},
@@ -306,7 +340,7 @@ module.exports = NodeHelper.create({
 		function(error, response, body) {
 			if (error) {
 				console.error("ERROR - MMM-Todoist: Task completion failed (attempt " + attempt + "): " + error);
-				
+
 				// Retry on network errors
 				if (attempt < maxRetries) {
 					var delay = Math.pow(2, attempt) * 1000; // Exponential backoff: 2s, 4s, 8s
@@ -337,7 +371,7 @@ module.exports = NodeHelper.create({
 					});
 					return;
 				}
-				
+
 				// Check sync_status for command result
 				if (responseJson.sync_status && responseJson.sync_status[uuid] === "ok") {
 					self.sendSocketNotification("TASK_COMPLETED", {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -39,8 +39,8 @@ const config = {
 	displayTasksWithoutDue: process.env.DISPLAY_TASKS_WITHOUT_DUE !== 'false', // default true
 	debug: process.env.DEBUG === 'true',
 	testCompleteTaskId: process.env.TEST_COMPLETE_TASK_ID || null,
-	apiVersion: 'v9',
-	apiBase: 'https://todoist.com/API',
+	apiVersion: 'v1',
+	apiBase: 'https://api.todoist.com/api',
 	todoistEndpoint: 'sync',
 	todoistResourceType: '["items", "projects", "collaborators", "user", "labels", "sections"]'
 };


### PR DESCRIPTION
## Summary

- **Migrate from Todoist Sync API v9 to v1** — Todoist shut down the v9 endpoint in Feb 2026, returning HTTP 410 Gone on all requests. The module was stuck showing "Loading..." with no indication of what was wrong. Updates `apiBase` and `apiVersion` to point to the new unified API v1 endpoint (`api.todoist.com/api/v1/sync/`).
- **Fix silent error handling in all API callbacks** — Previously, non-200 HTTP responses in `fetchTodos`, `addNewItemToList`, and `addNewSubItemToList` were silently swallowed (only logged to Node console). Now all error paths send socket notifications back to the frontend. Also wraps `JSON.parse` calls in try-catch to prevent uncaught exceptions.
- **Show error messages on the mirror** — When the module hasn't loaded yet and receives a `FETCH_ERROR`, it now displays the actual error on the mirror instead of "Loading..." forever.

## Test plan

- [ ] Verify module loads tasks with the new API v1 endpoint
- [ ] Verify task completion still works via the sync endpoint
- [ ] Verify task creation via inputTask buttons still works
- [ ] Test with an invalid token — mirror should show "Todoist Error: Todoist API returned HTTP 401" instead of "Loading..."
- [ ] Run `npm test` with a valid `.env` to confirm API connectivity